### PR TITLE
[Triton SM90 fix] transpose B matrix and let it contiguous along K dimension. Otherwise some shapes got errors

### DIFF
--- a/examples/matmul/triton/triton_matmul_sm90.py
+++ b/examples/matmul/triton/triton_matmul_sm90.py
@@ -191,6 +191,7 @@ def main(M, N, K, trials):
     torch.manual_seed(0)
     a = torch.randn((M, K), device="cuda", dtype=torch.float16)
     b = torch.randn((K, N), device="cuda", dtype=torch.float16)
+    b = b.T.contiguous()
     NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
     # Check constraints.
     assert a.dtype == b.dtype, "Incompatible dtypes"


### PR DESCRIPTION
Transpose B matrix is missing, which will lead to wrong shape. 

There is a `b = b.T.contiguous()` in Triton tutorial, mentioned [here](https://github.com/triton-lang/triton/blob/3ae95a858eac26088102075500e3860864432106/python/tutorials/09-persistent-matmul.py#L539) and [here](https://github.com/triton-lang/triton/blob/3ae95a858eac26088102075500e3860864432106/python/tutorials/09-persistent-matmul.py#L575)

I found this bug when I test the shape of (M, N, K) = (M, 49152,12288). M={256, 512, 1024, 2048, 4096, 8192, 16384}, and got the error: `Triton Error [CUDA]: an illegal memory access was encountered`. 

After the fix, this should be solved. 
